### PR TITLE
Change if-conditions

### DIFF
--- a/Classes/Composer/ClassAliasLoader.php
+++ b/Classes/Composer/ClassAliasLoader.php
@@ -99,13 +99,14 @@ class ClassAliasLoader {
 	 * @return bool|null
 	 */
 	public function loadClass($className) {
-		if (!$this->caseSensitiveClassLoading) {
+		$result = $this->composerClassLoader->loadClass($className);
+		if (!$result && !$this->caseSensitiveClassLoading) {
 			$lowerCasedClassName = strtolower($className);
 			if ($this->composerClassLoader->findFile($lowerCasedClassName)) {
-				return $this->composerClassLoader->loadClass($lowerCasedClassName);
+				$result = $this->composerClassLoader->loadClass($lowerCasedClassName);
 			}
 		}
-		return $this->composerClassLoader->loadClass($className);
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
On TYPO3 6.2 caseSensitiveClassLoading is FALSE by default. So with each class $this->composerClassLoader->loadClass() was loaded two times. In my eyes an overhead for a classLoader.