### PR TITLE
[TASK] Make aliased interfaces use class_alias

### DIFF
--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -71,8 +71,12 @@ class ClassAliasLoader
     {
         foreach ($aliasMap['aliasToClassNameMapping'] as $alias => $originalClassName) {
             $lowerCaseAlias = strtolower($alias);
-            $this->aliasMap['aliasToClassNameMapping'][$lowerCaseAlias] = $originalClassName;
-            $this->aliasMap['classNameToAliasMapping'][$originalClassName][$lowerCaseAlias] = $lowerCaseAlias;
+            if (substr($lowerCaseAlias, -9) === 'interface' && substr($originalClassName, -9) === 'Interface') {
+                class_alias($originalClassName, $alias);
+            } else {
+                $this->aliasMap['aliasToClassNameMapping'][$lowerCaseAlias] = $originalClassName;
+                $this->aliasMap['classNameToAliasMapping'][$originalClassName][$lowerCaseAlias] = $lowerCaseAlias;
+            }
         }
     }
 


### PR DESCRIPTION
If interfaces (and only interfaces) are not aliased with class_alias,
an error is presented that the alias is not compatible with the
original - which is technically true because the loaded class name
is in fact replaced with the original name. Using class_alias this
way allows an alias of an interface to be used in method signatures.